### PR TITLE
Add Support for Throwing Errors

### DIFF
--- a/ipapi.js
+++ b/ipapi.js
@@ -37,7 +37,7 @@ var _request = function(path, callback, isJson){
     });
 
     req.on('error', function(e) {
-      console.log('Request Error ! ' + e.message);
+      callback(new Error(e));
     });
 };
 


### PR DESCRIPTION
Instead of simply logging errors to the console, let the caller handle the error

Addresses #2